### PR TITLE
Fix "Unable to get URL by default action"

### DIFF
--- a/src/gifs.py
+++ b/src/gifs.py
@@ -92,7 +92,8 @@ def main(wf):
                          'Copy URL to clipboard',
                          arg=gif.url,
                          quicklookurl=gif.url,
-                         icon=gif.icon)
+                         icon=gif.icon,
+                         valid=True)
 
         # Alternate actions
         mod = it.add_modifier('cmd', 'Open in Browser', arg=gif.url)


### PR DESCRIPTION
I get stumble at error than I was clicking on Gif in Alfred Search Results and nothing happened. Turns our you should provide a value for valid param. Do not know any side effects of this change - for me it was a fix.